### PR TITLE
Paginate txns in address

### DIFF
--- a/src/components/Address.js
+++ b/src/components/Address.js
@@ -14,33 +14,58 @@ class Address extends React.Component {
   constructor() {
     super();
     this.state = {
-      loading: true
+      loading: true,
+      // FIXME: Set from redux
+      // XXX: This should render as `page + 1`
+      page: 0,
+      pageSize: 5
     };
+  }
+
+  getPageOfAddressTxns() {
+    const { addressId } = this.props;
+    const { latestBlockNumber, page, pageSize } = this.state;
+    const { web3 } = config;
+
+    let highBlockNumber = latestBlockNumber - page * pageSize;
+    highBlockNumber = highBlockNumber > 0 ? highBlockNumber : pageSize;
+
+    let lowBlockNumber = highBlockNumber > pageSize ? (highBlockNumber - pageSize) : "0";
+
+    return web3.eth.getPastLogs({
+      "fromBlock": String(lowBlockNumber),
+      "toBlock": String(highBlockNumber),
+      "address": addressId
+    });
   }
 
   componentDidMount() {
     const { addressId } = this.props;
     const { web3 } = config;
 
-    Promise.all([
-      web3.eth.getBalance(addressId, "latest"),
-      web3.eth.getPastLogs({
-        "fromBlock": "0x0",
-        "toBlock": "latest",
-        "address": addressId
-      }),
-      web3.eth.getCode(addressId, "latest"),
-    ]).then(([balance, transactions, code]) => {
-      this.setState({
-        loading: false,
-        addressInfo: {
-          id: addressId,
-          balance,
-          code,
-          transactions,
-        }
+    web3.eth
+      .getBlock("latest", false)
+      .then(block => {
+        this.setState({
+          latestBlockNumber: block.number
+        });
+
+        Promise.all([
+          web3.eth.getBalance(addressId, "latest"),
+          this.getPageOfAddressTxns(),
+          web3.eth.getCode(addressId, "latest"),
+        ]).then(([balance, transactions, code]) => {
+          this.setState({
+            loading: false,
+            addressInfo: {
+              id: addressId,
+              balance,
+              transactions,
+              code,
+            }
+          });
+        });
       });
-    });
   }
 
   render() {

--- a/src/components/Address.js
+++ b/src/components/Address.js
@@ -30,7 +30,7 @@ class Address extends React.Component {
     let highBlockNumber = latestBlockNumber - page * pageSize;
     highBlockNumber = highBlockNumber > 0 ? highBlockNumber : pageSize;
 
-    let lowBlockNumber = highBlockNumber > pageSize ? (highBlockNumber - pageSize) : "0";
+    let lowBlockNumber = highBlockNumber > pageSize ? (highBlockNumber - pageSize) : 0;
 
     return web3.eth.getPastLogs({
       "fromBlock": String(lowBlockNumber),

--- a/src/components/Blocks.js
+++ b/src/components/Blocks.js
@@ -8,7 +8,7 @@ class Blocks extends React.Component {
     super();
     this.state = {
       loading: true,
-      // FIXME: Set from query param
+      // FIXME: Set from redux
       // XXX: This should render as `page + 1`
       page: 0,
       pageSize: 5


### PR DESCRIPTION
**XXX** This is not the correct way to implement - fetching n transactions for a given address is an `n+1` problem. Using `web3.eth.getPastLogs` you can only control the block bounds, not a limit on the number of transactions returned.

So for `m` blocks you get `n` transactions where `n` is out of your control. In the typical case, no transactions are displayed.

Merging this will fix the performance problem but it is bad UX. We can have the correct UX if we have a denormalized auxiliary database.