### PR TITLE
feature: refactor block to use redux

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,9 +1,16 @@
 import Web3 from "web3";
 
+// Txns
 export const REQUEST_TRANSACTION = "REQUEST_TRANSACTION";
 export const RECEIVE_TRANSACTION = "RECEIVE_TRANSACTION";
 export const REQUEST_TRANSACTIONS_FOR_BLOCK = "REQUEST_TRANSACTIONS_FOR_BLOCK";
 export const RECEIVE_TRANSACTIONS_FOR_BLOCK = "RECEIVE_TRANSACTIONS_FOR_BLOCK";
+
+// Blocks
+export const REQUEST_BLOCK = "REQUEST_BLOCK";
+export const RECEIVE_BLOCK = "RECEIVE_BLOCK";
+
+// Search
 export const CLEAR_SEARCH_QUERY = "CLEAR_SEARCH_QUERY";
 export const UPDATE_SEARCH_QUERY = "UPDATE_SEARCH_QUERY";
 export const INVALID_SEARCH_QUERY = "INVALID_SEARCH_QUERY";
@@ -58,6 +65,30 @@ export function fetchTransactionsForBlock(id = "latest") {
     return web3.eth.getBlock(id, true).then(block => {
       dispatch(receiveTransactionsForBlock(id, block.transactions));
     });
+  };
+}
+
+export function fetchBlock(blockNumber) {
+  return function (dispatch) {
+    dispatch(requestBlock(blockNumber));
+    return web3.eth.getBlock(blockNumber, true).then(block => {
+      dispatch(receiveBlock(blockNumber, block));
+    });
+  };
+}
+
+export function requestBlock(blockNumber) {
+  return {
+    type: REQUEST_BLOCK,
+    blockNumber
+  };
+}
+
+export function receiveBlock(blockNumber, block) {
+  return {
+    type: RECEIVE_BLOCK,
+    blockNumber,
+    block
   };
 }
 

--- a/src/components/Block.js
+++ b/src/components/Block.js
@@ -1,40 +1,38 @@
 import React from "react";
 import { connect } from "react-redux";
-
 import BlockInfo from "./BlockInfo";
-import config from "../config";
+import { fetchBlock } from "../actions";
+import store from "../store";
+
 
 class Block extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      loading: true
-    };
+  componentDidMount() {
+    store.dispatch(fetchBlock(this.props.blockNumber));
   }
 
-  componentDidMount() {
-    const { web3 } = config;
-    web3.eth.getBlock(this.props.blockNumber, true).then(block => {
-      this.setState({
-        blockInfo: block,
-        loading: false
-      });
-    });
+  componentWillReceiveProps(nextProps) {
+    if (this.props.location.pathname !== nextProps.location.pathname) {
+      store.dispatch(fetchBlock(nextProps.blockNumber));
+    }
   }
 
   render() {
-    const { loading, blockInfo } = this.state;
+    const { blockFetching, blockInfo } = this.props;
 
     return (
       <div>
-        <div>{loading ? <p>Loading...</p> : <BlockInfo blockInfo={blockInfo} />}</div>
+        <div>{blockFetching ? <p>Loading...</p> : <BlockInfo blockInfo={blockInfo} />}</div>
       </div>
     );
   }
 }
 
 const mapStateToProps = (state, ownProps) => {
-  return { blockNumber: ownProps.match.params.blockNumber };
+  return {
+    blockNumber: ownProps.match.params.blockNumber,
+    blockInfo: state.blocks.block,
+    blockFetching: state.blocks.blockIsFetching
+  };
 };
 
 export default connect(mapStateToProps, null)(Block);

--- a/src/components/Transaction.js
+++ b/src/components/Transaction.js
@@ -9,6 +9,12 @@ class Transaction extends React.Component {
     store.dispatch(fetchTransaction(this.props.txId));
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.location.pathname !== nextProps.location.pathname) {
+      store.dispatch(fetchTransaction(nextProps.txId));
+    }
+  }
+
   render() {
     const { txId, txInfo, txFetching } = this.props;
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,8 @@ import {
   RECEIVE_TRANSACTION,
   REQUEST_TRANSACTIONS_FOR_BLOCK,
   RECEIVE_TRANSACTIONS_FOR_BLOCK,
+  REQUEST_BLOCK,
+  RECEIVE_BLOCK,
   CLEAR_SEARCH_QUERY,
   UPDATE_SEARCH_QUERY,
   INVALID_SEARCH_QUERY,
@@ -39,6 +41,26 @@ function transactions(
   }
 }
 
+// blocks data
+function blocks(
+  state = {
+    blockIsFetching: true,
+    block: null,
+  },
+  action
+) {
+  switch (action.type) {
+    case REQUEST_BLOCK:
+      return { ...state, blockIsFetching: true };
+    case RECEIVE_BLOCK:
+      return { ...state, blockIsFetching: false, block: action.block };
+    default:
+      return state;
+  }
+}
+
+// site search
+
 function search(state={ query: "", validQuery: true}, action) {
   switch(action.type) {
     case UPDATE_SEARCH_QUERY:
@@ -65,6 +87,7 @@ function search(state={ query: "", validQuery: true}, action) {
 
 export default combineReducers({
   routing: routerReducer,
+  blocks,
   transactions,
   search
 });


### PR DESCRIPTION
This also fixes a bug with the search bar. When searching for a `block|txn|address` while on a detail route for a `block|txn|address` the location update failed to trigger a fetch for the searched item. By adding an additional fetch in `componentWillReceiveProps` it will always update.

If the fix looks good I can apply it to `txn` and `address` as well.

**NOTE** The base of this branch is `r1b-searchbar-redux`.
  